### PR TITLE
Fix a few typos and deprecated np.object reference

### DIFF
--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook contains all the sample code and solutions to the exercices in chapter 2.*"
+    "*This notebook contains all the sample code and solutions to the exercises in chapter 2.*"
    ]
   },
   {
@@ -3747,7 +3747,7 @@
     "\n",
     "preprocessing = make_column_transformer(\n",
     "    (num_pipeline, make_column_selector(dtype_include=np.number)),\n",
-    "    (cat_pipeline, make_column_selector(dtype_include=np.object)),\n",
+    "    (cat_pipeline, make_column_selector(dtype_include=object)),\n",
     ")"
    ]
   },
@@ -3918,7 +3918,7 @@
     "        (\"log\", log_pipeline, [\"total_bedrooms\", \"total_rooms\",\n",
     "                               \"population\", \"households\", \"median_income\"]),\n",
     "        (\"geo\", cluster_simil, [\"latitude\", \"longitude\"]),\n",
-    "        (\"cat\", cat_pipeline, make_column_selector(dtype_include=np.object)),\n",
+    "        (\"cat\", cat_pipeline, make_column_selector(dtype_include=object)),\n",
     "    ],\n",
     "    remainder=default_num_pipeline)  # one column remaining: housing_median_age"
    ]
@@ -4381,7 +4381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Warning:** the following cell make take a few minutes to run:"
+    "**Warning:** the following cell may take a few minutes to run:"
    ]
   },
   {
@@ -4660,7 +4660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Warning:** the following cell make take a few minutes to run:"
+    "**Warning:** the following cell may take a few minutes to run:"
    ]
   },
   {
@@ -5214,7 +5214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, we could use a z-scores rather than t-scores—since the test set is not too small, it won't make a big difference:"
+    "Alternatively, we could use a z-score rather than a t-score. Since the test set is not too small, it won't make a big difference:"
    ]
   },
   {
@@ -5234,7 +5234,7 @@
     }
    ],
    "source": [
-    "# extra code – computes a confidence interval again using z-score\n",
+    "# extra code – computes a confidence interval again using a z-score\n",
     "zscore = stats.norm.ppf((1 + confidence) / 2)\n",
     "zmargin = zscore * squared_errors.std(ddof=1) / np.sqrt(m)\n",
     "np.sqrt(mean - zmargin), np.sqrt(mean + zmargin)"
@@ -5746,7 +5746,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Rather than restrict ourselves to k-Nearest Neighbors regressors, let's create a transform that accepts any regressor. For this, we can extend the `MetaEstimatorMixin` and have a required `estimator` argument in the constructor. The `fit()` method must work on a clone of this estimator, and it must also save `feature_names_in_`. The `MetaEstimatorMixin` will ensure that `estimator` is listed as a required parameters, and it will update `get_params()` and `set_params()` to make the estimator's hyperparameters available for tuning. Lastly, we create a `get_feature_names_out()` method: the output column name is the "
+    "Rather than restrict ourselves to k-Nearest Neighbors regressors, let's create a transformer that accepts any regressor. For this, we can extend the `MetaEstimatorMixin` and have a required `estimator` argument in the constructor. The `fit()` method must work on a clone of this estimator, and it must also save `feature_names_in_`. The `MetaEstimatorMixin` will ensure that `estimator` is listed as a required parameters, and it will update `get_params()` and `set_params()` to make the estimator's hyperparameters available for tuning. Lastly, we create a `get_feature_names_out()` method: the output column name is the ..."
    ]
   },
   {
@@ -6070,7 +6070,7 @@
     "        self.scale_ = X.std(axis=0)\n",
     "        self.n_features_in_ = X.shape[1]  # every estimator stores this in fit()\n",
     "        if hasattr(X_orig, \"columns\"):\n",
-    "            self.feature_names_in_ = np.array(X_orig.columns, dtype=np.object)\n",
+    "            self.feature_names_in_ = np.array(X_orig.columns, dtype=object)\n",
     "        return self  # always return self!\n",
     "\n",
     "    def transform(self, X):\n",
@@ -6133,7 +6133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's ensure we the transformation works as expected:"
+    "Now let's ensure the transformation works as expected:"
    ]
   },
   {


### PR DESCRIPTION
Hi @ageron!

Thank you for a great book! I'm looking forward to the final version of the third edition.

I've been running an updated notebook for Chapter 2 and corrected several typos. There were three deprecation messages concerning the use of `np.object` (please see `numpy` [release notes ](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) for clarification).
Please double-check and edit the following sentence in the Exercise 4 solution:
```
Lastly, we create a `get_feature_names_out()` method: the output column name is the 
```