### PR TITLE
Chapter 8: Clarify some comments and remove unnecessary ones, fix typo

### DIFF
--- a/08_dimensionality_reduction.ipynb
+++ b/08_dimensionality_reduction.ipynb
@@ -193,7 +193,6 @@
     "# extra code – this cell generates and saves Figure 8–2\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "from mpl_toolkits.mplot3d import Axes3D\n",
     "from sklearn.decomposition import PCA\n",
     "\n",
     "pca = PCA(n_components=2)\n",
@@ -601,7 +600,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "# X = [...]  # the small 3D dataset was created ealier in this notebook\n",
+    "# X = [...]  # the small 3D dataset was created earlier in this notebook\n",
     "X_centered = X - X.mean(axis=0)\n",
     "U, s, Vt = np.linalg.svd(X_centered)\n",
     "c1 = Vt[0]\n",
@@ -690,13 +689,6 @@
    ],
    "source": [
     "pca.components_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Recover the 3D points projected on the plane (PCA 2D subspace)."
    ]
   },
   {
@@ -863,13 +855,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Code to generate Figure 8–8. Explained variance as a function of the number of dimensions:**"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {},
@@ -888,6 +873,8 @@
     }
    ],
    "source": [
+    "# extra code – this cell generates and saves Figure 8–8\n",
+    "\n",
     "plt.figure(figsize=(6, 4))\n",
     "plt.plot(cumsum, linewidth=3)\n",
     "plt.axis([0, 400, 0, 1])\n",
@@ -1125,14 +1112,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Using `memmap()`:**"
+    "**Using NumPy's `memmap` class – a memory-map to an array stored in a binary file on disk.**"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create the `memmap()` structure, copy the MNIST training set into it, and call `flush()` which ensures that any data still in cache is saved to disk. This would typically be done by a first program:"
+    "Let's create the `memmap` instance, copy the MNIST training set into it, and call `flush()` which ensures that any data still in cache is saved to disk. This would typically be done by a first program:"
    ]
   },
   {
@@ -1267,7 +1254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Warning**: the following cell may take several minutes to run:"
+    "**Warning**, the following cell may take several minutes to run:"
    ]
   },
   {
@@ -1568,7 +1555,7 @@
     "    * It adds some complexity to your Machine Learning pipelines.\n",
     "    * Transformed features are often hard to interpret.\n",
     "2. The curse of dimensionality refers to the fact that many problems that do not exist in low-dimensional space arise in high-dimensional space. In Machine Learning, one common manifestation is the fact that randomly sampled high-dimensional vectors are generally far from one another, increasing the risk of overfitting and making it very difficult to identify patterns without having plenty of training data.\n",
-    "3. Once a dataset's dimensionality has been reduced using one of the algorithms we discussed, it is almost always impossible to perfectly reverse the operation, because some information gets lost during dimensionality reduction. Moreover, while some algorithms (such as PCA) have a simple reverse transformation procedure that can reconstruct a dataset relatively similar to the original, other algorithms (such as T-SNE) do not.\n",
+    "3. Once a dataset's dimensionality has been reduced using one of the algorithms we discussed, it is almost always impossible to perfectly reverse the operation, because some information gets lost during dimensionality reduction. Moreover, while some algorithms (such as PCA) have a simple reverse transformation procedure that can reconstruct a dataset relatively similar to the original, other algorithms (such as t-SNE) do not.\n",
     "4. PCA can be used to significantly reduce the dimensionality of most datasets, even if they are highly nonlinear, because it can at least get rid of useless dimensions. However, if there are no useless dimensions—as in the Swiss roll dataset—then reducing dimensionality with PCA will lose too much information. You want to unroll the Swiss roll, not squash it.\n",
     "5. That's a trick question: it depends on the dataset. Let's look at two extreme examples. First, suppose the dataset is composed of points that are almost perfectly aligned. In this case, PCA can reduce the dataset down to just one dimension while still preserving 95% of the variance. Now imagine that the dataset is composed of perfectly random points, scattered all around the 1,000 dimensions. In this case roughly 950 dimensions are required to preserve 95% of the variance. So the answer is, it depends on the dataset, and it could be any number between 1 and 950. Plotting the explained variance as a function of the number of dimensions is one way to get a rough idea of the dataset's intrinsic dimensionality.\n",
     "6. Regular PCA is the default, but it works only if the dataset fits in memory. Incremental PCA is useful for large datasets that don't fit in memory, but it is slower than regular PCA, so if the dataset fits in memory you should prefer regular PCA. Incremental PCA is also useful for online tasks, when you need to apply PCA on the fly, every time a new instance arrives. Randomized PCA is useful when you want to considerably reduce dimensionality and the dataset fits in memory; in this case, it is much faster than regular PCA. Finally, Random Projection is great for very high-dimensional datasets.\n",
@@ -2109,14 +2096,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Exercise: _Alternatively, you can write colored digits at the location of each instance, or even plot scaled-down versions of the digit images themselves (if you plot all digits, the visualization will be too cluttered, so you should either draw a random sample or plot an instance only if no other instance has already been plotted at a close distance). You should get a nice visualization with well-separated clusters of digits._"
+    "Exercise: _Alternatively, you can replace each dot in the scatterplot with the corresponding instance’s class (a digit from 0 to 9), or even plot scaled-down versions of the digit images themselves (if you plot all digits, the visualization will be too cluttered, so you should either draw a random sample or plot an instance only if no other instance has already been plotted at a close distance). You should get a nice visualization with well-separated clusters of digits._"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create a `plot_digits()` function that will draw a scatterplot (similar to the above scatterplots) plus write colored digits, with a minimum distance guaranteed between these digits. If the digit images are provided, they are plotted instead. This implementation was inspired from one of Scikit-Learn's excellent examples ([plot_lle_digits](http://scikit-learn.org/stable/auto_examples/manifold/plot_lle_digits.html), based on a different digit dataset)."
+    "Let's create a `plot_digits()` function that will draw a scatterplot (similar to the above scatterplots) plus write colored digits, with a minimum distance guaranteed between these digits. If the digit images are provided, they are plotted instead. This implementation was inspired from one of Scikit-Learn's excellent examples ([plot_lle_digits](https://scikit-learn.org/stable/auto_examples/manifold/plot_lle_digits.html), based on a different digit dataset)."
    ]
   },
   {
@@ -2400,7 +2387,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Warning**: the following cell will take about 10 minutes to run, depending on your hardware:"
+    "**Warning**, the following cell will take about 10-30 minutes to run, depending on your hardware:"
    ]
   },
   {
@@ -2446,7 +2433,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Warning**: the following cell will take about 10 minutes to run, depending on your hardware:"
+    "**Warning**, the following cell will take about 10-30 minutes to run, depending on your hardware:"
    ]
   },
   {


### PR DESCRIPTION
Hi @ageron,

Please find some fixes for the Chapter 8 notebook. For one of such fixes, the diff below doesn't show that the comment `"Recover the 3D points projected on the plane (PCA 2D subspace)."` is not followed by any code in the third edition and might be confusing (it was relevant in the previous edition). Moreover, there is an example of how to recover the points later in the notebook.
Other edits are self-explanatory :) 