### PR TITLE
Update 04_training_linear_models.ipynb

### DIFF
--- a/04_training_linear_models.ipynb
+++ b/04_training_linear_models.ipynb
@@ -869,6 +869,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Learning Curves"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
@@ -912,13 +919,6 @@
     "plt.grid()\n",
     "save_fig(\"high_degree_polynomials_plot\")\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Learning Curves"
    ]
   },
   {


### PR DESCRIPTION
Figure 4-14 was below the Polynomial Regression section but had to be below the Learning Curves section. It has been corrected.