### PR TITLE
add get_vocabulary() to see the learned vocabulary

### DIFF
--- a/13_loading_and_preprocessing_data.ipynb
+++ b/13_loading_and_preprocessing_data.ipynb
@@ -2833,6 +2833,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_vec_layer.get_vocabulary()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 102,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
Added a cell in "Chapter13/Text Processing".  
This would explain the output of `text_vec_layer(["Be good!", "Question: be or be?"])`. I suggest adding it to the PDF version as well.
```py
>>> text_vec_layer.get_vocabulary()
['', '[UNK]', 'be', 'to', 'the', 'thats', 'question']
```