### PR TITLE
Update 02_end_to_end_machine_learning_project.ipynb

### DIFF
--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -1205,7 +1205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "corr_matrix = housing.corr()"
+    "corr_matrix = housing.corr(numeric_only=True)"
    ]
   },
   {


### PR DESCRIPTION
Bonjour @Ageron, your book is helping a lot, I hope this helps you: Changed on line 1208 housing.corr() to housing.corr(numeric_only=True) to remove deprecated warning for future versions.