### PR TITLE
Add .devcontainer for Visual Studio Code and Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+# We create this Dockerfile to reuse existing published image as a container
+FROM ageron/handson-ml3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "handson-ml3",
+  "build": {
+    "context": "../docker",
+    "dockerfile": "Dockerfile"
+  },
+  "forwardPorts": [
+    6006,
+    8888
+  ],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/conda/envs/homl3"
+      },
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/nvidia-cuda:1": {
+      "cudaVersion": "11.8",
+      "installCudnn": true
+    }
+  },
+  "hostRequirements": {
+    "gpu": "optional"
+  },
+  "updateContentCommand": "conda init",
+  "postStartCommand": "/opt/conda/envs/homl3/bin/jupyter notebook --ip='0.0.0.0' --port=8888 --no-browser"
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ python. It contains the example code and solutions to the exercises in the third
 
 ⚠ _Colab provides a temporary environment: anything you do will be deleted after a while, so make sure you download any data you care about._
 
+You can also run these notebooks inside dev containers:
+
+* [![Open in Visual Studio Code](https://img.shields.io/static/v1?label=&message=Open%20in%20Visual%20Studio%20Code&color=blue&logo=visualstudiocode&style=flat)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/ageron/handson-ml3)
+* [![Open in Github Codespaces](https://img.shields.io/static/v1?label=&message=Open%20in%20Github%20Codespaces&color=2f362d&logo=github)](https://codespaces.new/ageron/handson-ml3?quickstart=1&hide_repo_select=true)
+
 <details>
 
 Other services may work as well, but I have not fully tested them:


### PR DESCRIPTION
This is a pretty minimal configuration to support [devcontainers](https://containers.dev/). It integrates nicely with the existing docker image and hopefully will help new learners to quickstart with the examples.

Fix #94 

PTAL @ageron (and thanks a lot for writing the book!)