### PR TITLE
Fix version for the docker image for CUDA

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -13,7 +13,7 @@ ARG UBUNTU_VERSION=20.04
 
 ARG ARCH=
 ARG CUDA=11.2
-FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}.1-base-ubuntu${UBUNTU_VERSION} as base
+FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}.2-base-ubuntu${UBUNTU_VERSION} as base
 # ARCH and CUDA are specified again because the FROM directive resets ARGs
 # (but their default value is retained if set previously)
 ARG ARCH


### PR DESCRIPTION
I built the GPU based Dockerfile but it was broken because the version of the CUDA image that it was trying to download is not available anymore, the next version (.2) fixes it.
