### PR TITLE
Update `sparse` to `sparse_output`

### DIFF
--- a/02_end_to_end_machine_learning_project.ipynb
+++ b/02_end_to_end_machine_learning_project.ipynb
@@ -2551,7 +2551,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, you can set `sparse=False` when creating the `OneHotEncoder`:"
+    "Alternatively, you can set `sparse_output=False` when creating the `OneHotEncoder`:"
    ]
   },
   {
@@ -2577,7 +2577,7 @@
     }
    ],
    "source": [
-    "cat_encoder = OneHotEncoder(sparse=False)\n",
+    "cat_encoder = OneHotEncoder(sparse_output=False)\n",
     "housing_cat_1hot = cat_encoder.fit_transform(housing_cat)\n",
     "housing_cat_1hot"
    ]


### PR DESCRIPTION
Update `sparse` to `sparse_output` when using OneHotEncoder in 02_end_to_end_machine_learning_project.ipynb

per warning :  

```
FutureWarning: `sparse` was renamed to `sparse_output` in version 1.2 and will be removed in 1.4. `sparse_output` is ignored unless you leave `sparse` to its default value.
```

.... not sure what we want to do once 1.4 is released.