### PR TITLE
16_nlp_with_rnns_and_attention, when using the model_ckpt

### DIFF
--- a/16_nlp_with_rnns_and_attention.ipynb
+++ b/16_nlp_with_rnns_and_attention.ipynb
@@ -555,7 +555,7 @@
     "model.compile(loss=\"sparse_categorical_crossentropy\", optimizer=\"nadam\",\n",
     "              metrics=[\"accuracy\"])\n",
     "model_ckpt = tf.keras.callbacks.ModelCheckpoint(\n",
-    "    \"my_shakespeare_model\", monitor=\"val_accuracy\", save_best_only=True)\n",
+    "    \"my_shakespeare_model.keras\", monitor=\"val_accuracy\", save_best_only=True)\n",
     "history = model.fit(train_set, validation_data=valid_set, epochs=10,\n",
     "                    callbacks=[model_ckpt])"
    ]


### PR DESCRIPTION
1. when creating the model checkpoint callback  :
model_ckpt = tf.keras.callbacks.ModelCheckpoint(
    "my_shakespeare_model"...)
IDE raise an error and advice me to use ".keras":
model_ckpt = tf.keras.callbacks.ModelCheckpoint(
    "my_shakespeare_model.keras"...)
and it works.
I guess it is caused by the keras version's differences.
2. when loading the pretrained model using:
shakespeare_model = tf.keras.models.load_model(model_path)
a similar error raised: "Keras 3 only supports V3 `.keras` files and legacy H5 format files (`.h5` extension). Note that the legacy SavedModel format is not supported by `load_model()` in Keras 3. "
I searched for answers, but I cann't make it right.  looking for help.
