### PR TITLE
Fix: Use global step in learning schedule for Mini-batch gradient descent

### DIFF
--- a/04_training_linear_models.ipynb
+++ b/04_training_linear_models.ipynb
@@ -2793,9 +2793,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:base] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-base-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2807,7 +2807,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.9.10"
   },
   "nav_menu": {},
   "toc": {

--- a/04_training_linear_models.ipynb
+++ b/04_training_linear_models.ipynb
@@ -692,7 +692,7 @@
     "        xi = X_b_shuffled[idx : idx + minibatch_size]\n",
     "        yi = y_shuffled[idx : idx + minibatch_size]\n",
     "        gradients = 2 / minibatch_size * xi.T @ (xi @ theta - yi)\n",
-    "        eta = learning_schedule(iteration)\n",
+    "        eta = learning_schedule(epoch * n_batches_per_epoch + iteration)\n",
     "        theta = theta - eta * gradients\n",
     "        theta_path_mgd.append(theta)\n",
     "\n",
@@ -2793,9 +2793,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2807,7 +2807,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.12.7"
   },
   "nav_menu": {},
   "toc": {


### PR DESCRIPTION
### **Fixes a learning rate decay issue in :**
**Chapter04**-Training Linear Models.
**Cell**: Mini-Batch Gradient Descent 

**Changed:**

`eta = learning_schedule(iteration)`

**to:**

```eta = learning_schedule(epoch * n_batches_per_epoch + iteration)```

### Why the change was needed:
The learning_schedule(t) function is designed to gradually decay the learning rate eta over time. In the current implementation, t is set to iteration, which resets to 0 at the beginning of each epoch. As a result, the learning rate also resets at each epoch, preventing smooth and consistent decay across the full training process(process of annealing).

This causes the optimizer to take larger steps at the beginning of each epoch, reducing the benefits of decaying learning rates (like convergence stability).

### How the fix works:
By setting t = epoch * n_batches_per_epoch + iteration, we:

Introduce a global step counter that increases monotonically from the start to the end of training.

Ensure that eta decays smoothly across all mini-batches over all epochs.

Restore the intended behavior of progressive learning rate decay, which helps achieve better convergence and training dynamics.

### Small but meaningful fix:
While this issue doesn’t cause the code to crash and the notebook still runs without it, it does affect the conceptual correctness of how learning rate decay is applied in mini-batch gradient descent. I thought it might be helpful for learners to have the logic align more closely with the theoretical explanation in the book.

Thanks for your time and for maintaining such a great resource!❤️

