### PR TITLE
Fix: Avoid pre-fitting final_estimator in StackingClassifier (Exercise:09)

### DIFF
--- a/07_ensemble_learning_and_random_forests.ipynb
+++ b/07_ensemble_learning_and_random_forests.ipynb
@@ -2002,7 +2002,7 @@
    ],
    "source": [
     "stack_clf = StackingClassifier(named_estimators,\n",
-    "                               final_estimator=rnd_forest_blender)\n",
+    "                               final_estimator=RandomForestClassifier(n_estimators=200,random_state=42))\n",
     "stack_clf.fit(X_train_full, y_train_full)"
    ]
   },


### PR DESCRIPTION
**Chapter 7 :** Ensemble Learning and Random Forests

In Exercise 9, a RandomForestClassifier is manually trained as a blender on the validation predictions:
`rnd_forest_blender = RandomForestClassifier(n_estimators=200, oob_score=True, random_state=42)
rnd_forest_blender.fit(X_valid_predictions, y_valid)`

This pre-trained model is then reused inside a StackingClassifier without setting `cv="prefit"`:
`stack_clf = StackingClassifier(
    named_estimators,
    final_estimator=rnd_forest_blender
)`

However, according to **Scikit-learn's API**:
" Unless cv='prefit' is explicitly set, all estimators passed to StackingClassifier (including the final_estimator) must be unfitted. StackingClassifier.fit() internally refits them using cross-validation."

###  Proposed Fix:
**Replace the pre-fitted final_estimator with a fresh, unfitted instance:**
`stack_clf = StackingClassifier(
    named_estimators,
    final_estimator=RandomForestClassifier(n_estimators=200, random_state=42)
)
stack_clf.fit(X_train_full, y_train_full)`

### Improves Accuracy:
**Original**: 0.9784  
**Proposed**:   0.9795
