### PR TITLE
Fix: Adjusted PiecewiseConstantDecay schedule to match training steps on Fashion MNIST

### DIFF
--- a/11_training_deep_neural_networks.ipynb
+++ b/11_training_deep_neural_networks.ipynb
@@ -2381,7 +2381,7 @@
    "outputs": [],
    "source": [
     "lr_schedule = tf.keras.optimizers.schedules.PiecewiseConstantDecay(\n",
-    "    boundaries=[6000,13_000 ],\n",
+    "    boundaries = [50_000 * n_epochs // batch_size, 80_000 * n_epochs // batch_size] ,\n",
     "    values=[0.01, 0.005, 0.001]\n",
     ")\n",
     "optimizer = tf.keras.optimizers.SGD(learning_rate=lr_schedule)"


### PR DESCRIPTION
**Chapter: 11**
**Cell: Piecewise Constant Scheduling**

### Issue:
In the **PiecewiseConstantDecay** example, the original boundaries were set to **[50000, 80000]**, but with 55,000 training images, batch size 32, and 10 epochs, total training steps are only about:

**55000 / 32 × 10 ≈ 17,190 steps**

The model never reaches the first boundary, and the learning rate never decays.

**So,I changed:**
`boundaries=[50_000, 80_000],`

**to:**
`boundaries=[6000, 13_000],`

Hope this PR might be meaningful.

### I’ve also opened a few other PRs recently  ->  


#202 
#205
