### PR TITLE
05_support_vector_machines.ipynb, remove sqrt

### DIFF
--- a/05_support_vector_machines.ipynb
+++ b/05_support_vector_machines.ipynb
@@ -2435,35 +2435,8 @@
    ],
    "source": [
     "y_pred = lin_svr.predict(X_train)\n",
-    "mse = root_mean_squared_error(y_train, y_pred)\n",
-    "mse"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's look at the RMSE:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 57,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.979565447829459"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "np.sqrt(mse)"
+    "rmse = root_mean_squared_error(y_train, y_pred)\n",
+    "rmse"
    ]
   },
   {


### PR DESCRIPTION
root_mean_squared_error() already takes the sqrt. No need to do it again