### PR TITLE
Fix: correct unpacking order in play_one_step (truncated/info swapped)

### DIFF
--- a/18_reinforcement_learning.ipynb
+++ b/18_reinforcement_learning.ipynb
@@ -1833,7 +1833,7 @@
     "    obs, info = env.reset()    \n",
     "    for step in range(200):\n",
     "        epsilon = max(1 - episode / 500, 0.01)\n",
-    "        obs, reward, done, info, truncated = play_one_step(env, obs, epsilon)\n",
+    "        obs, reward, done, truncated, info = play_one_step(env, obs, epsilon)\n",
     "        if done or truncated:\n",
     "            break\n",
     "\n",


### PR DESCRIPTION
**Chapter :18**
**Cell : 63 (Fixed Q-Value Targets)**
Play_one_step() returns (next_state, reward, done, truncated, info), but the training loop unpacked it as (obs, reward, done, info, truncated). 
### Fixed by using the correct order:
`obs, reward, done, truncated, info = play_one_step(env, obs, epsilon)
`